### PR TITLE
Add Akka.NET to DNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Please visit [dotnetfoundation.org](https://dotnetfoundation.org) for more infor
 
 There are many projects under the stewardship of the .NET Foundation. The [full list of projects](https://dotnetfoundation.org/projects?type=project) is provided on the .NET Foundation site. The projects on GitHub are listed below, categorized by contributing company or individual.
 
+
+**Akka.NET**
+
+- [Akka.NET](https://github.com/akkadotnet/akka.net)
+- [(and more)](https://github.com/akkadotnet)
+
 **AngleSharp**
 
 - [AngleSharp](https://github.com/AngleSharp/AngleSharp)

--- a/projects/akkadotnet.md
+++ b/projects/akkadotnet.md
@@ -5,7 +5,7 @@
 ## Project Details
 * [Project Info Site](https://getakka.net/) 
 * [Project Code Site](https://github.com/akkadotnet/akka.net)
-* Project License Type: [Apache License 2.0](https://aspnetwebstack.codeplex.com/license)
+* Project License Type: [Apache License 2.0](https://github.com/akkadotnet/akka.net/blob/dev/LICENSE)
 * Project Main Contact: [Aaron Stannard](https://github.com/Aaronontheweb)
 
 ## Quicklinks

--- a/projects/akkadotnet.md
+++ b/projects/akkadotnet.md
@@ -1,0 +1,17 @@
+# Akka.NET
+
+[Akka.NET](https://getakka.net) is a set of open-source libraries for designing scalable, resilient systems that span processor cores and networks. Akka allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
+
+## Project Details
+* [Project Info Site](https://getakka.net/) 
+* [Project Code Site](https://github.com/akkadotnet/akka.net)
+* Project License Type: [Apache License 2.0](https://aspnetwebstack.codeplex.com/license)
+* Project Main Contact: [Aaron Stannard](https://github.com/Aaronontheweb)
+
+## Quicklinks
+
+* [Contribute](https://github.com/akkadotnet/akka.net/blob/dev/CONTRIBUTING.md) 
+* [Documentation](https://getakka.net/articles/intro/what-is-akka.html)
+* [Discussions](http://gitter.im/akkadotnet/akka.net)
+* Twitter [@AkkaDotNet](https://twitter.com/AkkaDotNet)
+* StackOverflow Tag: [akka.net](http://stackoverflow.com/questions/tagged/akka.net)

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -129,7 +129,9 @@
 {"name":"dotvvm.md",
 "contributor": "DotVVM"},
 {"name":"imagesharp.md",
-"contributor": "SixLabors"}
+"contributor": "SixLabors"},
+{"name":"Akka.NET",
+"contributor":"Petabridge"}
 ],
 "contributors":
 [
@@ -226,7 +228,10 @@
  {"name": "DotVVM",
    "logo": "https://www.dotvvm.com/Content/img/logos/dotvvm_logo_square.png",
    "web": "https://www.dotvvm.com/"},
-{"name": "SixLabors",
-  "logo": "https://raw.githubusercontent.com/SixLabors/Branding/master/icons/org/sixlabors.256.png",
-  "web": "https://sixlabors.com/"}
+ {"name": "SixLabors",
+   "logo": "https://raw.githubusercontent.com/SixLabors/Branding/master/icons/org/sixlabors.256.png",
+   "web": "https://sixlabors.com/"},
+ {"name": "Petabridge",
+   "logo": "https://petabridge.com/images/logo.png",
+   "web": "https://petabridge.com"}
 ]}


### PR DESCRIPTION
Akka.NET was added to the DNF recently (see, https://github.com/akkadotnet/akka.net/pull/3189) but we are not yet listed on the public website.

This PR adds the Akka.NET md page and an entry to the main listing.
